### PR TITLE
No repeated errors, 'back to normal' status updates

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,3 +1,5 @@
+const jsonfile = require('jsonfile');
+
 const s = 1000;
 const m = s * 60;
 const h = m * 60;
@@ -49,6 +51,15 @@ const helpers = {
     });
     options.data.content += '```';
     return options.data.content;
+  },
+  writeJson: (jsonPath, data) => {
+    jsonfile.writeFile(jsonPath, data, err => {
+      if (err) {
+        console.error(
+          `[neoscan-status-reporter] There was an error while creating/updating testStatus.json file: ${err}`
+        );
+      }
+    });
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cityofzion/neoscan-status-reporter",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Jest reporter used by https://github.com/CityOfZion/neo-scan API tests to send test results with Discord.",
   "author": "Jakub Mucha <jakub.mucha@icloud.com> (https://github.com/drptbl)",
   "repository": "git@github.com:CityOfZion/neoscan-status-reporter.git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "axios": "0.18.0",
-    "env-ci": "2.1.0"
+    "env-ci": "2.1.0",
+    "jsonfile": "4.0.0"
   },
   "devDependencies": {
     "eslint": "4.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -439,7 +439,7 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.2:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -567,6 +567,12 @@ json-schema-traverse@^0.3.0:
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+
+jsonfile@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"


### PR DESCRIPTION
1. Won't send repeated errors anymore - if previous build ended in failure, it won't spam until it gets fixed to passing build.
2. Will send 'back to normal' status update once build passes from fail to success.